### PR TITLE
Use `cfg-if` to ensure it compiles (and tests) on all platforms.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,6 @@ repository = "https://github.com/shepmaster/cupid"
 documentation = "https://shepmaster.github.io/cupid/"
 
 license = "MIT"
+
+[dependencies]
+cfg-if = "0.1"


### PR DESCRIPTION
It's useless on non-x86 ones, but at least it successfully compiles.
