### PR TITLE
Make cpu query methods take references instead of consuming

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@ macro_rules! dump {
 
 macro_rules! delegate_flag {
     ($item:ident, {$($name:ident),+}) => {
-        $(pub fn $name(self) -> bool {
+        $(pub fn $name(&self) -> bool {
             self.$item.map(|i| i.$name()).unwrap_or(false)
         })+
     }


### PR DESCRIPTION
Previously, trying to run multiple queries on one Master struct did not compile, as the previous query moved the struct and destroyed it. All other query-able structs derived Copy, so this previously wasn't a problem, but Master can't as it contains non-copyable data.
