### PR TITLE
Add support for compiling on stable Rust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,13 @@
 language: rust
 sudo: false
 rust:
-- nightly
+- stable
+- beta
+
+matrix:
+  include:
+    - rust: nightly
+      script: cargo test && cargo test --features unstable
 env:
   global:
     secure: BrorZ5r3azkbWfieRJGPp0Uo7eoIM8ctn7CNCh1ORZy4elde2FTRPRQ3jboqugxdMCRD8rKZ6TAEChHNFnzZnycIzBIDXt97mSPk8Z7bVWBEKzDG640Ak7fWRA5oXnYVQvYJzatSwBb489XOPLeGPLd6waK0oVpvkzshcid7y1Rqc5exH9jeUU6FEUqKrQs+ugciQsEyeFzYigKVs8ATJZcAy8nDfQocvRB5YwemC7EoqiLxz7iDHjLxNlSxoN1ls30wbXlc5Tv/2dnvMO5QxRju0ep66A07QddXJ8p/AnjgFDRWe3q9ZrjTrGKV8QBzAn8qlk9x6S5Db9uDn5gQxDJza+UaXjTQc5V9xcZ9unEcrgtpuuFDzt+CovMVBsu+UW/8bnl7lwWdiBIKHw8sonRiOFcbvb86bMQy55ymwcJndTogSSnQO2UnobRMRgzqM5fenwYUtl6cC3PXE3jEcLngRdhvgPhewUOIDvsehxBFkDUaxbdSrlEnxgPQvpY14zMkBNSWBIgvIg8beykj0vbfrMxi4BLpAVGffXDO9d1gL1R2ZiB6YsDorYtKqAJeywS+2Q2OQAEHTO8mCKep/avMLeIvy4gNmszhpRPvP2I2GEn6YOT5nol+rBzrMIDVb6Zm/jnoZyR+o3K0rjChG0i18PuDnbsULeAS0DCiQGI=

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,13 @@ repository = "https://github.com/shepmaster/cupid"
 documentation = "https://shepmaster.github.io/cupid/"
 
 license = "MIT"
+build = "build.rs"
 
 [dependencies]
 cfg-if = "0.1"
+
+[build-dependencies]
+gcc = "0.3"
+
+[features]
+unstable = []

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,36 @@
+extern crate gcc;
+
+use std::env;
+
+fn main() {
+    if env::var("CARGO_FEATURE_UNSTABLE").is_ok() {
+        return
+    }
+
+    let target = env::var("TARGET").unwrap();
+
+    // not supported on non-x86 platforms
+    if !target.starts_with("x86_64") &&
+       !target.starts_with("i686") &&
+       !target.starts_with("i586") {
+        return
+    }
+
+    let mut cfg = gcc::Config::new();
+    let msvc = target.contains("msvc");
+    if target.starts_with("x86_64") {
+        cfg.file(if msvc {"src/arch/x86_64.asm"} else {"src/arch/x86_64.S"});
+        cfg.define("X86_64", None);
+    } else {
+        cfg.file(if msvc {"src/arch/i686.asm"} else {"src/arch/i686.S"});
+        cfg.define("X86", None);
+    }
+    if target.contains("darwin") {
+        cfg.define("APPLE", None);
+    }
+    if target.contains("windows") {
+        cfg.define("WINDOWS", None);
+    }
+    cfg.include("src/arch");
+    cfg.compile("libcupid.a");
+}

--- a/src/arch/asm.h
+++ b/src/arch/asm.h
@@ -1,0 +1,5 @@
+#if defined(APPLE) || (defined(WINDOWS) && defined(X86))
+#define GLOBAL(name) .globl _ ## name; _ ## name
+#else
+#define GLOBAL(name) .globl name; name
+#endif

--- a/src/arch/i686.S
+++ b/src/arch/i686.S
@@ -1,0 +1,36 @@
+#include <asm.h>
+
+.text
+
+// windows conventions: ??
+// unix conventions: http://wiki.osdev.org/Calling_Conventions
+
+GLOBAL(__cupid_cpuid_0_2):
+    // frame prologue
+    push %ebp
+    mov %esp, %ebp
+
+    // save registers
+    push %ebx
+    push %esi
+
+    // Set up arguments to cpuid
+    mov 8(%ebp), %eax
+    xor %ecx, %ecx
+
+    cpuid
+
+    // Store all return values
+    mov 12(%ebp), %esi
+    mov %eax, (%esi)
+    mov %ebx, 4(%esi)
+    mov %ecx, 8(%esi)
+    mov %edx, 12(%esi)
+
+    // restore registers
+    pop %esi
+    pop %ebx
+
+    // epilogue
+    pop %ebp
+    ret

--- a/src/arch/i686.asm
+++ b/src/arch/i686.asm
@@ -1,0 +1,31 @@
+.586
+.MODEL FLAT, C
+.CODE
+
+; this is all copied from i686.S
+__cupid_cpuid_0_2 PROC
+    PUSH EBP
+    MOV EBP, ESP
+
+    PUSH EBX
+    PUSH ESI
+
+    MOV EAX, DWORD PTR [EBP + 8]
+    XOR ECX, ECX
+
+    CPUID
+
+    MOV ESI, DWORD PTR [EBP + 12]
+    MOV DWORD PTR [ESI], EAX
+    MOV DWORD PTR [ESI + 4], EBX
+    MOV DWORD PTR [ESI + 8], ECX
+    MOV DWORD PTR [ESI + 12], EDX
+
+    POP ESI
+    POP EBX
+
+    POP EBP
+    RET
+__cupid_cpuid_0_2 ENDP
+
+END

--- a/src/arch/x86_64.S
+++ b/src/arch/x86_64.S
@@ -1,0 +1,41 @@
+#include <asm.h>
+
+.text
+
+#if defined(WINDOWS)
+// convention: https://msdn.microsoft.com/en-us/library/zthk2dkh.aspx
+// saved registers: https://msdn.microsoft.com/en-us/library/6t169e9c.aspx
+#define ARG1 %ecx
+#define ARG2 %rdx
+#else
+// conventions: http://stackoverflow.com/questions/18024672
+#define ARG1 %edi
+#define ARG2 %rsi
+#endif
+
+
+GLOBAL(__cupid_cpuid_0_2):
+    // save callee saved registers that we'll clobber
+    push %rbx
+    push %rsi
+
+    // save off our return pointer on all platforms
+    mov ARG2, %rsi
+
+    // set up inputs to cpuid
+    mov ARG1, %eax
+    xor %rcx, %rcx
+
+    cpuid
+
+    // Store return values of cpuid
+    mov %eax, (%rsi)
+    mov %ebx, 4(%rsi)
+    mov %ecx, 8(%rsi)
+    mov %edx, 12(%rsi)
+
+    // Restore registers
+    pop %rsi
+    pop %rbx
+
+    ret

--- a/src/arch/x86_64.asm
+++ b/src/arch/x86_64.asm
@@ -1,0 +1,27 @@
+_text SEGMENT
+
+; copied from x86_64.S
+__cupid_cpuid_0_2 PROC
+    PUSH RBX
+    PUSH RSI
+
+    MOV RSI, RDX
+
+    MOV EAX, ECX
+    XOR RCX, RCX
+
+    CPUID
+
+    MOV DWORD PTR [RSI], EAX
+    MOV DWORD PTR [RSI + 4], EBX
+    MOV DWORD PTR [RSI + 8], ECX
+    MOV DWORD PTR [RSI + 12], EDX
+
+    POP RSI
+    POP RBX
+
+    RET
+
+__cupid_cpuid_0_2 ENDP
+
+END


### PR DESCRIPTION
Use the `gcc` crate with some assembly stubs for the various platforms to
compile in the support for calling out to the native `cpuid` instruction. A
Cargo feature is used to enable the use of `asm!`.