### PR TITLE
test stable/unstable build results and bugfix for unstable builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,8 @@ rust:
 matrix:
   include:
     - rust: nightly
-      script: cargo test && cargo test --features unstable
+      script: |
+        cargo test && cargo test --features unstable
+        cargo run > stable
+        cargo run --features unstable > unstable
+        diff stable unstable

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@ cfg_if! {
                      "={edx}"(res4)
                      : // input operands
                      "{eax}"(code as u32),
-                     "{ecx}"(0 as u32)
+                     "{ecx}"(code2 as u32)
                      : // clobbers
                      : // options
                      );


### PR DESCRIPTION
The test in the first commit did not pass, but it should.

The second commit contains the bugfix, the value of the ECX register was ignored in unstable builds.